### PR TITLE
Omit end line from GitHub URL hash for single line selections

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
 	"displayName": "Copy Github Permalink",
 	"description": "Copy Github Permalink",
 	"icon": "img/ico.png",
-	"version": "1.0.2",
+	"version": "1.0.3",
 	"homepage": "https://github.com/tejanium/vscode-copy-github-permalink/blob/master/README.md",
 	"bugs": {
 		"url": "https://github.com/tejanium/vscode-copy-github-permalink/issues"

--- a/src/model/permalink.ts
+++ b/src/model/permalink.ts
@@ -14,7 +14,10 @@ export class Permalink {
 		const { sha } = await this.git.shaMaster(branch);
 
 		const start = this.editor.selection.start.line + 1;
-		const end = this.editor.selection.end.line + 1;
+		const end =
+			this.editor.selection.end.line > this.editor.selection.start.line
+				? `-L${this.editor.selection.end.line + 1}`
+				: '';
 
 		const file = vscode.workspace.asRelativePath(this.editor.document.uri);
 

--- a/src/test/suite/extension.test.ts
+++ b/src/test/suite/extension.test.ts
@@ -55,7 +55,7 @@ suite('Test commands', () => {
 			await vscode.commands.executeCommand('copy-github-permalink.copy');
 
 			sandbox.assert.calledWith(infoStub, 'Copied permalink to HEAD.');
-			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1-L1');
+			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1');
 		});
 
 		test('Git remote is HTTP', async () => {
@@ -67,7 +67,7 @@ suite('Test commands', () => {
 			await vscode.commands.executeCommand('copy-github-permalink.copy');
 
 			sandbox.assert.calledWith(infoStub, 'Copied permalink to HEAD.');
-			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1-L1');
+			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1');
 		});
 
 		test('Git remote is HTTPS', async () => {
@@ -79,7 +79,7 @@ suite('Test commands', () => {
 			await vscode.commands.executeCommand('copy-github-permalink.copy');
 
 			sandbox.assert.calledWith(infoStub, 'Copied permalink to HEAD.');
-			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1-L1');
+			assert.strictEqual(await vscode.env.clipboard.readText(), 'https://github.com/owner/name/blob/sha1234567890/test/fixtures/file.txt#L1');
 		});
 
 		test('Display copied information and put the link of all lines to clipboard', async () => {


### PR DESCRIPTION
Avoid outputting hashes of the format #L1-L1 when the start line equals the end line.